### PR TITLE
Upcomming & past meetings

### DIFF
--- a/NMWeb/src/app/meeting-list/meeting-list.component.html
+++ b/NMWeb/src/app/meeting-list/meeting-list.component.html
@@ -6,11 +6,20 @@
   </mat-list-item>
 </ng-template>
 
-<h2>Past Meetings</h2>
+<button
+  class="pastMeetingsButton"
+  *ngIf="pastMeetings && pastMeetings.length > 0"
+  (click)="seePastMeetings = !seePastMeetings"
+  mat-raised-button>
+  <span *ngIf="!seePastMeetings">See past meetings</span>
+  <span *ngIf="seePastMeetings">Hide past meetings</span>
+</button>
 
-
-<ng-template mat-list ngFor let-item [ngForOf]="pastMeetings" >
-  <mat-list-item>
-    <app-meeting-list-item mat-list-item [meeting]="item" formcontrolname="meeting"></app-meeting-list-item>
-  </mat-list-item>
+<ng-template [ngIf]="seePastMeetings">
+  <h2>Past Meetings</h2>
+  <ng-template mat-list ngFor let-item [ngForOf]="pastMeetings" >
+    <mat-list-item>
+      <app-meeting-list-item mat-list-item [meeting]="item" formcontrolname="meeting"></app-meeting-list-item>
+    </mat-list-item>
+  </ng-template>
 </ng-template>

--- a/NMWeb/src/app/meeting-list/meeting-list.component.html
+++ b/NMWeb/src/app/meeting-list/meeting-list.component.html
@@ -1,13 +1,17 @@
 <h2>Upcomming Meetings</h2>
 
-<ng-template mat-list ngFor let-item [ngForOf]="upcommingMeetings" >
+<ng-template mat-list ngFor let-item [ngForOf]="upcomingMeetings" >
   <mat-list-item>
     <app-meeting-list-item mat-list-item [meeting]="item" formcontrolname="meeting"></app-meeting-list-item>
   </mat-list-item>
 </ng-template>
 
+<ng-template [ngIf]="upcomingMeetings.length === 0">
+  <h3 class="no-upcoming-meetings">There are no upcoming meetings</h3>
+</ng-template>
+
 <button
-  class="pastMeetingsButton"
+  class="past-meetings-button"
   *ngIf="pastMeetings && pastMeetings.length > 0"
   (click)="seePastMeetings = !seePastMeetings"
   mat-raised-button>

--- a/NMWeb/src/app/meeting-list/meeting-list.component.html
+++ b/NMWeb/src/app/meeting-list/meeting-list.component.html
@@ -1,7 +1,16 @@
-<h2>Meetings</h2>
+<h2>Upcomming Meetings</h2>
 
-<ng-template mat-list ngFor let-item [ngForOf]="items | async" >
-    <mat-list-item>
-      <app-meeting-list-item mat-list-item [meeting]="item" formcontrolname="meeting"></app-meeting-list-item>
-    </mat-list-item>
+<ng-template mat-list ngFor let-item [ngForOf]="upcommingMeetings" >
+  <mat-list-item>
+    <app-meeting-list-item mat-list-item [meeting]="item" formcontrolname="meeting"></app-meeting-list-item>
+  </mat-list-item>
+</ng-template>
+
+<h2>Past Meetings</h2>
+
+
+<ng-template mat-list ngFor let-item [ngForOf]="pastMeetings" >
+  <mat-list-item>
+    <app-meeting-list-item mat-list-item [meeting]="item" formcontrolname="meeting"></app-meeting-list-item>
+  </mat-list-item>
 </ng-template>

--- a/NMWeb/src/app/meeting-list/meeting-list.component.scss
+++ b/NMWeb/src/app/meeting-list/meeting-list.component.scss
@@ -1,0 +1,3 @@
+.pastMeetingsButton {
+  margin: 5px;
+}

--- a/NMWeb/src/app/meeting-list/meeting-list.component.scss
+++ b/NMWeb/src/app/meeting-list/meeting-list.component.scss
@@ -1,3 +1,10 @@
-.pastMeetingsButton {
+.past-meetings-button {
   margin: 5px;
+}
+
+.no-upcoming-meetings {
+  width: 80%;
+  margin: 10%;
+  color: lightgrey;
+  text-align: center;
 }

--- a/NMWeb/src/app/meeting-list/meeting-list.component.ts
+++ b/NMWeb/src/app/meeting-list/meeting-list.component.ts
@@ -14,18 +14,12 @@ export class MeetingListComponent implements OnInit {
 
   constructor(private meetingsService: MeetingsService) {
     this.meetingsService.retrieveAllMeetings().subscribe((meetings: Meeting[]) => {
-      let today = new Date();
-      this.pastMeetings = meetings.filter((meeting) =>  {
-        return !meeting.date || isNaN(new Date(meeting.date).getTime()) || new Date(meeting.date).getTime() < today.getTime();
-      });
-
-      this.upcommingMeetings = meetings.filter((meeting) =>  {
-        return meeting.date && new Date(meeting.date).getTime() >= today.getTime();
-      });
+      this.pastMeetings = meetings.filter(meeting => this.meetingsService.isPastMeeting(meeting));
+      this.upcommingMeetings = meetings.filter(meeting => this.meetingsService.isUpcommingMeeting(meeting));
     });
   }
 
   ngOnInit() {
-  }
 
+  }
 }

--- a/NMWeb/src/app/meeting-list/meeting-list.component.ts
+++ b/NMWeb/src/app/meeting-list/meeting-list.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit } from '@angular/core';
-import {DbList} from '../shared/db.service';
 import {Meeting, MeetingsService} from '../shared/meetings.service'
 
 @Component({
@@ -9,10 +8,20 @@ import {Meeting, MeetingsService} from '../shared/meetings.service'
 })
 export class MeetingListComponent implements OnInit {
 
-  items: DbList<Meeting>;
+  pastMeetings: Meeting[];
+  upcommingMeetings: Meeting[];
 
   constructor(private meetingsService: MeetingsService) {
-    this.items = this.meetingsService.retrieveAllMeetings();
+    this.meetingsService.retrieveAllMeetings().subscribe((meetings: Meeting[]) => {
+      let today = new Date();
+      this.pastMeetings = meetings.filter((meeting) =>  {
+        return !meeting.date || isNaN(new Date(meeting.date).getTime()) || new Date(meeting.date).getTime() < today.getTime();
+      });
+
+      this.upcommingMeetings = meetings.filter((meeting) =>  {
+        return meeting.date && new Date(meeting.date).getTime() >= today.getTime();
+      });
+    });
   }
 
   ngOnInit() {

--- a/NMWeb/src/app/meeting-list/meeting-list.component.ts
+++ b/NMWeb/src/app/meeting-list/meeting-list.component.ts
@@ -10,6 +10,7 @@ export class MeetingListComponent implements OnInit {
 
   pastMeetings: Meeting[];
   upcommingMeetings: Meeting[];
+  seePastMeetings = false;
 
   constructor(private meetingsService: MeetingsService) {
     this.meetingsService.retrieveAllMeetings().subscribe((meetings: Meeting[]) => {

--- a/NMWeb/src/app/meeting-list/meeting-list.component.ts
+++ b/NMWeb/src/app/meeting-list/meeting-list.component.ts
@@ -8,15 +8,16 @@ import {Meeting, MeetingsService} from '../shared/meetings.service'
 })
 export class MeetingListComponent implements OnInit {
 
-  pastMeetings: Meeting[];
-  upcommingMeetings: Meeting[];
+  pastMeetings: Meeting[] = [];
+  upcomingMeetings: Meeting[] = [];
   seePastMeetings = false;
 
   constructor(private meetingsService: MeetingsService) {
     this.meetingsService.retrieveAllMeetings().subscribe((meetings: Meeting[]) => {
       this.pastMeetings = meetings.filter(meeting => this.meetingsService.isPastMeeting(meeting));
-      this.upcommingMeetings = meetings.filter(meeting => this.meetingsService.isUpcommingMeeting(meeting));
+      this.upcomingMeetings = meetings.filter(meeting => this.meetingsService.isUpcomingMeeting(meeting));
     });
+
   }
 
   ngOnInit() {

--- a/NMWeb/src/app/shared/meetings.service.ts
+++ b/NMWeb/src/app/shared/meetings.service.ts
@@ -29,7 +29,7 @@ export class MeetingsService {
     return !meeting.date || isNaN(new Date(meeting.date).getTime()) || new Date(meeting.date).getTime() < today.getTime();
   }
 
-  isUpcommingMeeting(meeting: Meeting) {
+  isUpcomingMeeting(meeting: Meeting) {
     let today = new Date();
     return meeting.date && new Date(meeting.date).getTime() >= today.getTime();
   }

--- a/NMWeb/src/app/shared/meetings.service.ts
+++ b/NMWeb/src/app/shared/meetings.service.ts
@@ -23,4 +23,14 @@ export class MeetingsService {
   retrieveAllMeetings(): DbList<Meeting> {
     return this.db.list(this.MEETINGS_PATH);
   }
+
+  isPastMeeting(meeting: Meeting) {
+    let today = new Date();
+    return !meeting.date || isNaN(new Date(meeting.date).getTime()) || new Date(meeting.date).getTime() < today.getTime();
+  }
+
+  isUpcommingMeeting(meeting: Meeting) {
+    let today = new Date();
+    return meeting.date && new Date(meeting.date).getTime() >= today.getTime();
+  }
 }


### PR DESCRIPTION
Divides the meeting page in two sections. The meetings that have no date or an incorrect format are supposed to have already happened. We have to change the dates of two meetings that follows the yy/dd/mm American format to the yy/mm/dd format.