### PR TITLE
#242 On mobile, map options darkened rectangle is too wide, bugfix/map-issue-242

### DIFF
--- a/NMWeb/src/app/maps/users-map-page/users-map-page.component.html
+++ b/NMWeb/src/app/maps/users-map-page/users-map-page.component.html
@@ -27,7 +27,7 @@
         <p>There are <b>{{ numberOfNearUsers }}</b> map points within {{ radiusSearch | distance }}.</p>
       </ng-template>
 
-      <div class="filter-buttons">
+      <div class="filter-buttons" fxLayout fxLayout.lt-sm="column">
         <mat-checkbox
           checked="showLabelsOverMarker"
           (change)="changeShowLabelOverMark()"

--- a/NMWeb/src/app/maps/users-map-page/users-map-page.component.scss
+++ b/NMWeb/src/app/maps/users-map-page/users-map-page.component.scss
@@ -26,6 +26,9 @@ $distance-slicer-width: 300px;
     1px 0 $blur-radius $names,
     0 -1px $blur-radius $names;
 
+  mat-checkbox {
+    padding: 5px;
+  }
 }
 
 agm-map {

--- a/NMWeb/src/app/topics/topics-map-shared/topics-map-shared.module.ts
+++ b/NMWeb/src/app/topics/topics-map-shared/topics-map-shared.module.ts
@@ -6,6 +6,7 @@ import {MapsSharedModule} from '../../maps-shared/maps-shared.module'
 import {MatSliderModule} from '@angular/material'
 import {FormsModule} from '@angular/forms'
 import { TopicsDetailsService } from '../topic-details-page/topics-details.service'
+import { FlexLayoutModule } from '@angular/flex-layout';
 
 @NgModule({
   imports: [
@@ -13,7 +14,8 @@ import { TopicsDetailsService } from '../topic-details-page/topics-details.servi
     SharedModule,
     MapsSharedModule,
     MatSliderModule,
-    FormsModule
+    FormsModule,
+    FlexLayoutModule
   ],
   declarations: [
     TopicsMapComponent

--- a/NMWeb/src/app/topics/topics-map-shared/topics-map.component.html
+++ b/NMWeb/src/app/topics/topics-map-shared/topics-map.component.html
@@ -1,5 +1,6 @@
 <div class="container">
-  <div class="icons-size">
+  <div class="icons-size" fxLayout fxLayout.lt-sm="column">
+    <div fxLayout fxLayoutAlign="center center">
     <span>Icons size:</span>
     <mat-slider
       min="4"
@@ -8,7 +9,8 @@
       [(ngModel)]="iconBaseSize"
       (change)="onIconBaseSizeChange()"
     ></mat-slider>
-
+    </div>
+    <div fxLayout fxLayoutAlign="center center">
     <ng-template [ngIf]="topics.length > 1">
       <span>Separation:</span>
       <mat-slider
@@ -19,7 +21,7 @@
         (change)="onOffsetRadiusChange()"
       ></mat-slider>
     </ng-template>
-
+    </div>
   </div>
 
   <agm-map #agmMap

--- a/NMWeb/src/app/topics/topics-map-shared/topics-map.component.scss
+++ b/NMWeb/src/app/topics/topics-map-shared/topics-map.component.scss
@@ -16,6 +16,15 @@
   padding-right: 10px;
   border-radius: 5px;
   background: rgba($color: #111111, $alpha: 0.5);
+
+  div {
+    padding-left: 5px;
+    width: 210px;
+  }
+
+  span {
+    white-space: nowrap;
+  }
 }
 
 agm-map {


### PR DESCRIPTION
### IMPORTANT: Checklist before committing / pull-request:
- [x] IMPORTANT: Please read this checklist and checkmark the items, putting `[x]` at the beginning of the bullet-point
- [x] Think of the reviewers and make their life easier :) while also keeping You reputation good by committing high-quality code and avoiding bad-quality commits
- [x] Self-review before committing, with graphical diff (e.g. IDE like WebStorm), ideally with per-character diff highlight.
- [x] Provide descriptive commit message, pull-request titles and branch names, including issue number in commit message, e.g. #123
- [x] "Boy Scout Rule" - try to leave code in a bit better state than when You found it. Or at least don't leave it in worse state.
- [x] Proper indentation. Two spaces in Angular.
- [x] Use spell-checker built into Your IDE
- [x] Avoid compiler warnings or tslint / codelyzer / IDE warnings
- [ ] Run unit tests `npm test` and TestCafe `cd e2e-testcafe ; npm i && npm test`
- [ ] Check Continuous Integration (CI) build status (takes about 1m30s) after pushing
- [x] Small files / modules / classes / methods / components (Single Responsibility Principle). Even if a given thing seems like it will not be re-used, it should be split off, for the sake of making it easier to analyse it (and maybe it will actually be reused in the future or a new implementation will be developed / experimented-on in the future)
- [x] Don't put random changes in pull-requests, e.g. reformatting entire files, changing quotes to double/single, etc. For the sake of easier reviewing and not polluting `git annotate`
- [x] Please follow platform / language / library style guides
  - camelCaseVariableNames
  - CamelCaseClassNames  
- [x] Avoid duplicate code. Do not copy-paste ~2 or more lines. Instead, extract component / class / method / function and reuse in all places. For the sake of future maintenance.
- [ ] Test on mobile resolutions. Manually and via `cd e2e-testcafe ; npm i && npm test:all`
- [x] Complex structured data should be displayed using HTML, not plaintext (applies e.g. to popups / tooltips as well), for styling it to make it more readable and look better, being able to add icons, images, links, etc.
  - [x] Prefer *components* over pipes, for things that might need some varying styling inside (even things like numbers-with-separators, currency, dates, time). Can `:host { display: inline }`.
- [x] Naming:
  - [x] Avoid cryptic/short names like `a`, `x`, etc
  - [x] Use names consistent with the name of the type, like `user: User`, `dialogService: DialogService`
  - [x] Use existing terminology/naming (look in related code to see what terms/names are used)
  - [x] Avoid using vague terms like `data`, `info`, `object`. Prefer to be more descriptive.
  - [x] Don't give alias names to `@Input()`-s
- [x] If possible, use existing utility functions, e.g. from Lodash, for example things like `sumBy`
- [x] Wrapping margin should be at about ~120-140 chars (160 columns an absolute maximum). Don't start new significant stuff beyond column 100 (just continuation of existing stuff). The logic is to see the significant stuff on a laptop screen, while seeing whole lines on big monitor. But since TypeScript is not Java, it is easier to keep lines shorter :).
- [x] Should: Make little video/screenshots if there are user visible changes. On mobile and desktop resolutions (can be just one video showing different screen sizes / responsive). This is to speed up review and feedback for people who are e.g. not at their computer or cannot checkout/run from source.

Thank You :)

![map2](https://user-images.githubusercontent.com/39878713/62491957-a707dd80-b7cd-11e9-86a3-dc1b8f6382e0.png)
![map1](https://user-images.githubusercontent.com/39878713/62491962-a7a07400-b7cd-11e9-9eb0-e12d3d067e1e.png)
![map4](https://user-images.githubusercontent.com/39878713/62491960-a707dd80-b7cd-11e9-9025-27e7eee48e8c.png)
![map3](https://user-images.githubusercontent.com/39878713/62491958-a707dd80-b7cd-11e9-9400-82cc4c637ba5.png)


