### PR TITLE
#241, #219 - bugfix/map-issues-241,219 

### DIFF
--- a/NMWeb/src/app/app.component.scss
+++ b/NMWeb/src/app/app.component.scss
@@ -1,21 +1,22 @@
+@import '~variables.scss';
+
 app-header {
   position: relative;
   z-index: 100;
 }
 
 .content-container{
-    margin-top:0px;
-    margin-left:21px;
-    padding:10px;
+    margin: 0 0 0 21px;
+    padding: $toolbar-height 10px 0 10px;
     overflow-x: hidden;
-    min-height: 87.5vh;
-    max-height: 87.5vh;
+    height: 100%;
+    min-height: calc(100vh - #{$footer-height} - #{$toolbar-height});
 }
 
 app-footer{
   width: 100%;
-  position: absolute;
-  top: 95vh;
+  position: relative;
+  bottom: 0;
   right: 0;
   margin: 0;
   padding: 0;
@@ -24,6 +25,9 @@ app-footer{
 
 mat-sidenav {
   width: 200px;
+  position: fixed !important;
+  top: $toolbar-height !important;
+  height: 100vh;
 }
 
 app-wrapper {
@@ -34,9 +38,13 @@ app-wrapper {
 @media only screen and (max-width: 600px) {
   .content-container{
     overflow-y: scroll;
-    min-height: 91.8vh;
-    max-height: 91.8vh;
     margin-left:5px;
+    padding: $toolbar-height-mobile 10px 0 10px;
+    min-height: calc(100vh - #{$toolbar-height-mobile});
+  }
+
+  mat-sidenav {
+    top: $toolbar-height-mobile !important;
   }
 }
 

--- a/NMWeb/src/app/core/footer/footer.component.scss
+++ b/NMWeb/src/app/core/footer/footer.component.scss
@@ -1,4 +1,5 @@
-$footer-height: 5vh;
+@import '~variables.scss';
+
 $max-screen-width: 600px;
 $facebook-color:#3b5998;
 $medium-color:#1c9963;

--- a/NMWeb/src/app/core/header/header.component.html
+++ b/NMWeb/src/app/core/header/header.component.html
@@ -5,7 +5,7 @@
           class="menu-button tf-toolbar-btn"
           (click)="sidenav.toggle()">
     <mat-icon>menu</mat-icon>
-  </button>￼
+  </button>
 
   <a routerLink="" class="logo" fxLayout fxLayoutAlign="center center">
     <img

--- a/NMWeb/src/app/core/header/header.component.html
+++ b/NMWeb/src/app/core/header/header.component.html
@@ -1,4 +1,5 @@
 <mat-toolbar>
+  <div class="toolbar-left" fxLayout>
   <button mat-icon-button
           id='menuButtonHamburger'
           class="menu-button tf-toolbar-btn"
@@ -6,7 +7,7 @@
     <mat-icon>menu</mat-icon>
   </button>￼
 
-  <a routerLink="">
+  <a routerLink="" class="logo" fxLayout fxLayoutAlign="center center">
     <img
       src="assets/images/TopicFriendsLogo4.svg"
       class="tf-icon"
@@ -15,7 +16,7 @@
       &nbsp;β
     </span>
   </a>
-
+  </div>
   <span class="toolbar-spacer"></span>
 
   <app-header-user-account-button style="height: 100%"

--- a/NMWeb/src/app/core/header/header.component.scss
+++ b/NMWeb/src/app/core/header/header.component.scss
@@ -1,14 +1,16 @@
-$tool-bar-height: 5vh;
+@import '~variables.scss';
 
 .tf-icon {
-  height: 4vh;
-  margin-left: 10px;
+  height: 25px;
+  padding: 0 5px;
+  width: 100%;
 }
 
 .betta-icon {
   color: white;
   font-family: serif;
-  font-size: 3vh;
+  font-size: 20px;
+  margin-left: -15px;;
 }
 
 .toolbar-icon {
@@ -25,13 +27,12 @@ $tool-bar-height: 5vh;
 
 .mat-toolbar {
   width: 100%;
-  height: $tool-bar-height;
-  padding-right: 0;
+  height: $toolbar-height;
+  padding: 0;
   user-select: none;
   //background: rgba(255, 255, 255, 0.75);
-  background: rgba(0, 0, 0, 1);
+  background: transparent;
   color: black;
-  box-shadow: 0 3px 5px -1px rgba(0, 0, 0, .2), 0 6px 10px 0 rgba(0, 0, 0, .14), 0 1px 18px 0 rgba(0, 0, 0, .12);
 
   a {
     text-decoration: none;
@@ -43,32 +44,34 @@ $tool-bar-height: 5vh;
   }
 }
 
-.menu-button {
-  margin-left: -10px;
-}
 
 
 mat-toolbar {
-  //margin-left: 10px !important;
-  padding-left: 10px !important;
-  position: relative;
+  position: fixed;
+  top: 0;
+  left: 0;
   z-index: 100;
+}
+
+.logo {
+  background-color: black;
+  padding-right: 10px;
+  height: 100%;
+}
+
+.toolbar-left {
+  height: 100%;
+  width: 150px;
 }
 
 @media only screen and (max-width: 600px) {
   .mat-toolbar {
-    height: 40px !important;
+    height: $toolbar-height-mobile;
   }
 
-  .tf-icon {
-    height: 30px !important;
-  }
 
   button {
-    height: 40px !important;
+    height: $toolbar-height-mobile;
   }
 
-  .betta-icon {
-    font-size: 25px !important;
-  }
 }

--- a/NMWeb/src/app/core/header/header.component.scss
+++ b/NMWeb/src/app/core/header/header.component.scss
@@ -2,7 +2,7 @@
 
 .tf-icon {
   height: 25px;
-  padding: 0 5px;
+  padding-left: 5px;
   width: 100%;
 }
 
@@ -10,7 +10,8 @@
   color: white;
   font-family: serif;
   font-size: 20px;
-  margin-left: -15px;;
+  margin-left: -3px;
+  padding-right: 10px;
 }
 
 .toolbar-icon {

--- a/NMWeb/src/app/core/header/header.component.scss
+++ b/NMWeb/src/app/core/header/header.component.scss
@@ -67,6 +67,7 @@ mat-toolbar {
 @media only screen and (max-width: 600px) {
   .mat-toolbar {
     height: $toolbar-height-mobile;
+    background: black;
   }
 
 

--- a/NMWeb/src/app/maps/users-map-page/users-map-page.component.scss
+++ b/NMWeb/src/app/maps/users-map-page/users-map-page.component.scss
@@ -31,8 +31,7 @@ $distance-slicer-width: 300px;
 agm-map {
   width: 100%;
   height: 100%;
-  max-height: 95vh;
-  position: absolute;
+  position: fixed;
   top: 0px;
   left: 0px;
 

--- a/NMWeb/src/app/topics/topics-map-page/topics-map-page.component.scss
+++ b/NMWeb/src/app/topics/topics-map-page/topics-map-page.component.scss
@@ -7,9 +7,8 @@ $map-mobile-width: 100%;
 
 app-topics-map {
   width: 100%;
-  height: 100%;
-  max-height: 95vh;
-  position: absolute;
+  height: 100vh;
+  position: fixed;
   top: 0px;
   left: 0px;
 }

--- a/NMWeb/src/app/topics/topics-map-shared/topics-map.component.scss
+++ b/NMWeb/src/app/topics/topics-map-shared/topics-map.component.scss
@@ -11,7 +11,7 @@
   position: absolute;
   color: white;
   z-index: 1;
-  margin: 10px 0px 0px 6px;
+  margin: 55px 0px 0px 6px;
   padding-left: 10px;
   padding-right: 10px;
   border-radius: 5px;

--- a/NMWeb/src/app/user-profile-details/user-profile-details.component.scss
+++ b/NMWeb/src/app/user-profile-details/user-profile-details.component.scss
@@ -16,8 +16,8 @@ mat-form-field {
 .save-fab {
   position: fixed;
   z-index: 2;
-  top: calc(100vh - 120px);
-  left: calc(100vw - 100px);
+  bottom: 20px;
+  right: 20px;
 }
 
 .saveProfileButton {
@@ -25,11 +25,3 @@ mat-form-field {
   margin-left: 10%;
 }
 
-@media only screen and (max-width: 600px) {
-  .save-fab {
-    position: fixed;
-    z-index: 2;
-    top: calc(100vh - 80px);
-    left: calc(100vw - 80px);
-  }
-}

--- a/NMWeb/src/variables.scss
+++ b/NMWeb/src/variables.scss
@@ -1,1 +1,5 @@
 $max-screen-width: 600px;
+
+$toolbar-height: 45px;
+$toolbar-height-mobile: 40px;
+$footer-height: 30px;


### PR DESCRIPTION
### IMPORTANT: Checklist before committing / pull-request:
- [x] IMPORTANT: Please read this checklist and checkmark the items, putting `[x]` at the beginning of the bullet-point
- [x] Think of the reviewers and make their life easier :) while also keeping You reputation good by committing high-quality code and avoiding bad-quality commits
- [x] Self-review before committing, with graphical diff (e.g. IDE like WebStorm), ideally with per-character diff highlight.
- [x] Provide descriptive commit message, pull-request titles and branch names, including issue number in commit message, e.g. #123
- [x] "Boy Scout Rule" - try to leave code in a bit better state than when You found it. Or at least don't leave it in worse state.
- [x] Proper indentation. Two spaces in Angular.
- [x] Use spell-checker built into Your IDE
- [ ] Avoid compiler warnings or tslint / codelyzer / IDE warnings
- [ ] Run unit tests `npm test` and TestCafe `cd e2e-testcafe ; npm i && npm test`
- [ ] Check Continuous Integration (CI) build status (takes about 1m30s) after pushing
- [x] Small files / modules / classes / methods / components (Single Responsibility Principle). Even if a given thing seems like it will not be re-used, it should be split off, for the sake of making it easier to analyse it (and maybe it will actually be reused in the future or a new implementation will be developed / experimented-on in the future)
- [x] Don't put random changes in pull-requests, e.g. reformatting entire files, changing quotes to double/single, etc. For the sake of easier reviewing and not polluting `git annotate`
- [x] Please follow platform / language / library style guides
  - camelCaseVariableNames
  - CamelCaseClassNames  
- [x] Avoid duplicate code. Do not copy-paste ~2 or more lines. Instead, extract component / class / method / function and reuse in all places. For the sake of future maintenance.
- [ ] Test on mobile resolutions. Manually and via `cd e2e-testcafe ; npm i && npm test:all`
- [x] Complex structured data should be displayed using HTML, not plaintext (applies e.g. to popups / tooltips as well), for styling it to make it more readable and look better, being able to add icons, images, links, etc.
  - [x] Prefer *components* over pipes, for things that might need some varying styling inside (even things like numbers-with-separators, currency, dates, time). Can `:host { display: inline }`.
- [x] Naming:
  - [x] Avoid cryptic/short names like `a`, `x`, etc
  - [x] Use names consistent with the name of the type, like `user: User`, `dialogService: DialogService`
  - [x] Use existing terminology/naming (look in related code to see what terms/names are used)
  - [x] Avoid using vague terms like `data`, `info`, `object`. Prefer to be more descriptive.
  - [x] Don't give alias names to `@Input()`-s
- [x] If possible, use existing utility functions, e.g. from Lodash, for example things like `sumBy`
- [x] Wrapping margin should be at about ~120-140 chars (160 columns an absolute maximum). Don't start new significant stuff beyond column 100 (just continuation of existing stuff). The logic is to see the significant stuff on a laptop screen, while seeing whole lines on big monitor. But since TypeScript is not Java, it is easier to keep lines shorter :).
- [x] Should: Make little video/screenshots if there are user visible changes. On mobile and desktop resolutions (can be just one video showing different screen sizes / responsive). This is to speed up review and feedback for people who are e.g. not at their computer or cannot checkout/run from source.

Thank You :)

![map12](https://user-images.githubusercontent.com/39878713/62662189-7a8dc600-b973-11e9-855e-b9d6dc683faa.png)
![map14](https://user-images.githubusercontent.com/39878713/62662192-7b265c80-b973-11e9-90eb-918f00a5cbc0.png)
![map11](https://user-images.githubusercontent.com/39878713/62662193-7b265c80-b973-11e9-9110-d44a36d17ff7.png)
![map13](https://user-images.githubusercontent.com/39878713/62662191-7a8dc600-b973-11e9-8955-d150eb1fe182.png)
